### PR TITLE
Adding opta deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com//nocodb/nocodb-seed-heroku)
 
 
-[![Deploy](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-button.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fnocodb%2Fnocodb-seed-heroku%2Fblob%2Fmain%2Fopta.yaml&name=NocoDB)
+[![Deploy](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-using-opta.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fnocodb%2Fnocodb-seed-heroku%2Fblob%2Fmain%2Fopta.yaml&name=NocoDB)

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com//nocodb/nocodb-seed-heroku)
 
+
+[![Deploy](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-button.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fnocodb%2Fnocodb-seed-heroku%2Fblob%2Fmain%2Fopta.yaml&name=NocoDB)

--- a/opta.yaml
+++ b/opta.yaml
@@ -1,0 +1,33 @@
+name: nocodb
+org_name: <<org_name::org_name::Your Organization Name>>
+providers:
+  aws:
+    region: <<region::aws_region::Your AWS Region>>
+    account_id: <<account_id::aws_account_id::Your AWS Account ID>>
+modules:
+  - type: base
+  - type: dns
+    domain: <domain::string::The dns domain for your NocoDB deployment>>
+    delegated: false # set to true once ready https://docs.opta.dev/miscellaneous/ingress/
+  - type: k8s-cluster
+  - type: k8s-base
+    name: k8sbase
+  - type: cloudfront-distribution
+    # acm_cert_arn: arn:aws:acm:{aws.region}:{aws.account_id}:certificate/<valid_arn_id>    # Use the ACM cert ARN here
+    # domains:
+    #   - {module.dns.domain}
+    links:
+      - k8sbase
+  - name: pg
+    type: postgres
+    safety: false
+  - type: k8s-service
+    env_vars:
+      - name: NC_DB
+        value: "pg://${{module.pg.db_host}}:5432?u=${{module.pg.db_user}}&p=${{module.pg.db_password}}&d=${{module.pg.db_name}}"
+    public_uri: "/"
+    port:
+      tcp: 8080
+    image: nocodb/nocodb
+    links:
+      - pg

--- a/opta.yaml
+++ b/opta.yaml
@@ -15,7 +15,7 @@ modules:
   - type: cloudfront-distribution
     # acm_cert_arn: arn:aws:acm:{aws.region}:{aws.account_id}:certificate/<valid_arn_id>    # Use the ACM cert ARN here
     # domains:
-    #   - {module.dns.domain}
+    #   - ${{module.dns.domain}}
     links:
       - k8sbase
   - name: pg

--- a/opta.yaml
+++ b/opta.yaml
@@ -7,7 +7,7 @@ providers:
 modules:
   - type: base
   - type: dns
-    domain: <domain::string::The dns domain for your NocoDB deployment>>
+    domain: <<domain::string::The dns domain for your NocoDB deployment>>
     delegated: false # set to true once ready https://docs.opta.dev/miscellaneous/ingress/
   - type: k8s-cluster
   - type: k8s-base


### PR DESCRIPTION
### Summary
This PR adds a button that allows users to deploy NocoDB to AWS using a tool called [Opta](https://github.com/run-x/opta). It works as follows:

The button links a user to a form, where the user fills out some configuration that Opta requires (similar to Heroku's deploy button). This configuration is used to generate an Opta configuration file, which is generated from this template.
The user downloads the generated configuration file and the Opta CLI, and then prepares their AWS credentials locally
The user deploys using the Opta CLI and the generated configuration file!
The NocoDB instance created by this tool will have persistent storage, as well as a robust database managed by RDS.

### Testing
**Note that the HTML for the button in this PR does not work yet, as it points to a file at the path https://github.com/nocodb/nocodb-seed-heroku/blob/main/opta.yaml. This path will become valid after this PR is merged. In order to help in testing, I've added a button below which is equivalent, but points to the forked repo that this request is coming from:

[![Deploy](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-using-opta.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fnsarupr%2Fnocodb-seed-heroku%2Fblob%2Fadding-opta-deploy%2Fopta.yaml&name=NocoDB)

### Additional Information

Related PRs: https://github.com/nocodb/nocodb/pull/1128

### Screenshots

<img width="1792" alt="Screenshot 2022-02-08 at 6 34 27 PM" src="https://user-images.githubusercontent.com/20905988/152992668-1415bf0b-7e62-4f53-89e4-dddc07b2efc7.png">


<img width="1792" alt="Screenshot 2022-02-08 at 6 32 25 PM" src="https://user-images.githubusercontent.com/20905988/152992451-8c826ffc-6e0b-4962-a125-8dbeeef9c49c.png">

