### PR TITLE
Fix the Deploy to Render button link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com//nocodb/nocodb-seed-heroku)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/nocodb/nocodb-seed-heroku)
 
 
 [![Deploy](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-using-opta.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fnocodb%2Fnocodb-seed-heroku%2Fblob%2Fmain%2Fopta.yaml&name=NocoDB)


### PR DESCRIPTION
The link has an extra `/`, which prevents Render from deploying the service.