### PR TITLE
Enabling usage of free tier in Render config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
   name: nocodb
   env: docker
   autoDeploy: false
-  healthCheckPath: /dashboard
+  healthCheckPath: /dashboard/
   region: frankfurt
   plan: free
   envVars:

--- a/render.yaml
+++ b/render.yaml
@@ -1,17 +1,19 @@
 services:
 - type: web
-  name: xc
+  name: nocodb
   env: docker
   autoDeploy: false
   healthCheckPath: /dashboard
+  region: frankfurt
   plan: free
   envVars:
   - key: DATABASE_URL
     fromDatabase:
-      name: xc
+      name: nocodb
       property: connectionString
   - key: PORT
     value: 8080
 databases:
-- name: xc
+- name: nocodb
+  region: frankfurt
   plan: free

--- a/render.yaml
+++ b/render.yaml
@@ -4,6 +4,7 @@ services:
   env: docker
   autoDeploy: false
   healthCheckPath: /dashboard
+  plan: free
   envVars:
   - key: DATABASE_URL
     fromDatabase:
@@ -13,3 +14,4 @@ services:
     value: 8080
 databases:
 - name: xc
+  plan: free


### PR DESCRIPTION
By default Render assigns paid instances if not configured otherwise in the `render.yaml` file. To provide a better experience for new users I would propose changing the configuration.