### PR TITLE
Fix deploy to Heroku button

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
   "stack": "container",
   "addons": [
     {
-      "plan": "heroku-postgresql:hobby-dev"
+      "plan": "heroku-postgresql:essential-0"
     }
   ],
    "env": {


### PR DESCRIPTION
This PR resolves this Issue #9

There have already been other PRs against for the same issue.
But the minimum PostgreSQL plan's name in Heroku was changed again.


